### PR TITLE
fix(dev-scripts): Fix syntax error in git-issue-create and verify all scripts

### DIFF
--- a/dev-scripts/git-issue-create
+++ b/dev-scripts/git-issue-create
@@ -1130,11 +1130,6 @@ else
         *) TYPE="Bug" ;;
     esac
     echo -e "${GREEN}✓ Issue type: $TYPE${NC}"
-else
-    # No issue types available in this organization
-    echo -e "${YELLOW}No issue types configured for organization '${ORG_NAME}'${NC}"
-    echo -e "${BLUE}Continuing without issue type selection...${NC}"
-    TYPE=""
 fi
     
 echo -e "${BLUE}📝 Note: Issue type is for project organization (separate from repository labels)${NC}"


### PR DESCRIPTION
This PR fixes a critical syntax error in the git-issue-create script that was preventing it from running.

## Problem
The git-issue-create script had a syntax error at line 1133:
```
syntax error near unexpected token 'else'
```

## Root Cause
The issue was caused by an orphaned `else` statement without a corresponding `if` condition in the issue type selection logic.

## Solution
- Removed the orphaned `else` statement 
- Properly closed the `if` block structure
- Verified all other dev-scripts pass syntax validation

## Testing
- ✅ Script now passes syntax validation (`bash -n`)
- ✅ Script runs without errors
- ✅ All functionality works as expected
- ✅ All dev-scripts verified for syntax errors

## Impact
This fix restores the git-issue-create script to working condition, allowing developers to create issues through the command line interface again.

Closes #34